### PR TITLE
Add governance doc's

### DIFF
--- a/LICENSE-APACHE-2.0
+++ b/LICENSE-APACHE-2.0
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2023 MDIP Coalition
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-CC-BY-4.0
+++ b/LICENSE-CC-BY-4.0
@@ -1,0 +1,311 @@
+[Creative Commons Attribution 4.0 International Public License](https://creativecommons.org/licenses/by/4.0/)
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.

--- a/LICENSES
+++ b/LICENSES
@@ -1,0 +1,22 @@
+The contents of this repository are Copyright 2023 by MDIP Coalition and licensed as follows:
+
+[Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+All code, its parameters and tests including the contents of:
+
+- `/.github`
+- `*.py`
+- `*.yml`
+- `*.yaml`
+- `*.json`
+- `*.html`
+
+[CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)
+
+All documentation, images and resources:
+
+- `/assets`
+- `/docs`
+- `/samples/*/TIDES`
+- `*.md`
+- `*.pdf`

--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -95,3 +95,73 @@ In developing the Principles and related resources, the MDIP coalition has adopt
        - Tabular data schemas(i.e. csvs): [frictionless data table, data resource or data package](https://frictionlessdata.io/standards/)  
        - Tagged data schemas: [json-schema](https://json-schema.org/), or [XML schema definition](https://en.wikipedia.org/wiki/XML_Schema_(W3C))  
      - Uses structured releases, versions, or changelogs.  
+
+## Project Definitiomns
+
+<a name="mdip_communication_assets"></a>
+**MDIP Communication Assets**
+:    Presentations, artwork, contacts, and written work developed by the MDIP Co-authors and/or MDIP Manager in support of the Principles including but not limited to: the MDIP Website, logos and artwork, mailing lists, handouts, press releases and presentations located on the MDIP Shared Folder.
+
+<a name="mdip_community"></a>
+**MDIP Community**
+:    The combined members of MDIP Coalition, MDIP Co-signatories, MDIP Manager, MDIP Co-author Coordinator and MDIP Stakeholders.
+
+<a name="mdip_definitions"></a>
+**MDIP Definitions**
+:    Terms of art as officially defined by the MDIP Community and approved by the MDIP Coalition. Currently documented (here) at: [https://www.interoperablemobility.org/definitions/]
+
+<a name="mdip_documentation"></a>
+**MDIP Documentation**
+:    Supporting documents and text for implementing the Principles including MDIP Definitions, and MDIP Implementation Responsibilities.
+
+<a name="mdip_governance"></a>
+**MDIP Governance**
+:    Who and how decisions are made about the scope and direction of the MDIP Project as approved by the Co-author Coalition and documented at: ….
+
+<a name="mdip_files"></a>
+**MDIP Files**
+:    The digital files located within the MDIP Shared Folder including – but not limited to – drafts of various MDIP Resources, MDIP Documentation and MDIP Community Assets as well as digital assets used to manage the day-to-day aspects of the MDIP Project and further its mission.
+
+<a name="mdip_implementation_responsibilities"></a>
+**MDIP Implementation Responsibilities**
+:    The directive list of responsibilities for implementing the Principles as approved by the MDIP Coalition. Currently documented at: [https://www.interoperablemobility.org/implementation/]
+
+<a name="mdip_project_roadmap"></a>
+**MDIP Project Roadmap**
+:    Near- and medium-term priorities of the MDIP Project in pursuit of the Principles as approved by the MDIP Coalition.
+
+<a name="mdip_procurement_resource"></a>
+**MDIP Procurement Resource**
+:    Documentation of why and how interoperability should be included in a transit technology procurement and example language which can be directly leveraged.
+
+<a name="mdip_respository"></a>
+**MDIP Repository**
+:    The version control repository containing the MDIP Website; currently located at:
+[`https://github.com/interoperable-mobility/principles`]
+
+<a name="mdip_repository_organization"></a>
+**MDIP Repository Organization**
+:    The version control organization which contains the MDIP Repository. Currently located at: [`https://github.com/interoperable-mobility`]
+
+<a name="mdip_resources"></a>
+**MDIP Resources**
+:    Products developed by the MDIP Community and approved by the Co-author Coalition in support of the Principles.  Examples include:
+     - Procurement Resource
+     - Mobility Dataverse (forthcoming)
+     - Open Standards Project Template (forthcoming)
+
+<a name="mdip_shared_folder"></a>
+**MDIP Shared Folder**
+:    Location for storing and collaborating on MDIP Files managed by the MDIP Manager.
+
+<a name="mdip_website"></a>
+**MDIP Website**
+:    Web location and website content stored on the MDIP Repository and available at [`http://interoperablemobility.org`]
+
+<a name="mobility_dataverse"></a>
+**Mobility Dataverse**
+:    A (forthcoming) catalog of data standards and products which support them which are in alignment with or have the potential to be in alignment with the Principles – as well as an assessment of any gaps in that alignment.
+
+<a name="normative_change"></a>
+**Normative Change**
+:    A change in the intent or meaning of a document, text, or artwork.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,95 @@
+# MDIP Project Governance
+
+!!! tip
+
+    When capitalized in this document, the words “MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" refer to their respective definitions in RFC 2119.
+
+This document outlines the roles, policies, procedures, and structures that guide the collaborative and transparent stewardship of the Mobility Data Interoperability Principles  (“MDIP”) Project. The MDIP Project is a collaborative effort by government agencies, mobility service providers, and nonprofit organizations that are dedicated to changing the relationship between transit and technology. MDIP establishes a vision for the transit industry in which all mobility data is communicated by interoperable technology components using open standards. Interoperability is the next step for the software and hardware that support transit operations, planning, reporting, and the rider experience. It is a necessary condition for transit to keep pace with the changing world of personal mobility and to develop service that meets the expectations of the riding public.
+
+!!! tip "Definitions"
+
+    This document references many terms of art related to the project which are defined in [definitions page](definitions.md).
+
+The rest of this document is organized as follows:
+
+- [Governance Principles](#governance-principles)
+- [Roles](#roles)
+- [Document Changelog](#document-changelog)
+
+The people and organizations filling roles articulated in this document are articulated in the document
+
+## Governance Principles
+
+The Mobility Data Interoperability Principle’s Governance is designed with the following principles in mind:
+
+- Accountability,
+- Collegiality,
+- Transparency, and
+- Effective stewardship.
+
+## Roles
+
+The following roles for individuals, groups and organizations are defined as part of the MDIP Governance:
+
+- [MDIP Coalition](#mdip-coalition)
+- [MDIP Coalition Chair](#mdip-coalition-chair)
+- [MDIP Coalition Organizational Representative](#mdip-coalition-organizational-representative)
+- [MDIP Coalition Coordinator](#mdip-coalition-coordinator)
+- [MDIP Co-signatories](#mdip-co-signatories)
+- [MDIP Manager](#mdip-manager)
+- [MDIP Program Manager](#mdip-program-manager)
+
+### MDIP Coalition
+
+Public sector and nonprofit organizations that are committed to realizing the vision of the Principles and serve as the governing body for the [MDIP Project](definitions.md#mdip_project). If no [MDIP Manager](#mdip-manager) is selected, the MDIP Coalition MUST be responsible for their activities as well.
+
+### MDIP Coalition Chair
+
+Chosen by the [MDIP Coalition](#mdip-coalition), this person MUST act as the lead of the body and be responsible for chairing [MDIP Coalition](#mdip-coalition) meetings and working with the [MDIP Program Manager](#mdip-program-manager) and [MDIP Coalition Coordinator](#mdip-coalition-coordinator) for scheduling agendizing them.
+
+### MDIP Coalition Organizational Representative
+
+An individual within their organization who is responsible for communication and voting activity as a member of the [MDIP Coalition](#mdip-coalition).
+
+### MDIP Coalition Coordinator
+
+Chosen by the [MDIP Coalition](#mdip-coalition), this individual MUST be responsible for coordinating the actions and activities of the [MDIP Coalition](#mdip-coalition) including:
+
+- scheduling and agendizing [MDIP Coalition](#mdip-coalition) meetings in consultation with the MDIP Coalition Chair and [MDIP Program Manager](#mdip-program-manager); and
+- recording and publicizing [MDIP Coalition](#mdip-coalition) actions.
+
+### MDIP Co-signatories
+
+Individuals or organizations who have asked to be publicly recognized for their agreement with the Principles.
+
+### MDIP Manager
+
+Chosen by the [MDIP Coalition](#mdip-coalition), this individual or organization MUST oversee daily management of the [MDIP Project](definitions#mdip_project) at the direction of the [MDIP Coalition](#mdip-coalition)in pursuit of the [MDIP Project Roadmap](definitions.md#mdip_project_roadmap) consistent with available resources, including:
+Identifying, pursuing, and managing human and monetary resources available to the [MDIP Project](definitions#mdip_project) (e.g. grant opportunities);
+
+- Building and demonstrating consensus that the mobility industry should be organized around interoperable technology in alignment with the Principles;
+- Maintaining a high-profile in relevant venues and conduct targeted direct outreach which establishes the MDIP Project as the leader in the mobility data interoperability space;
+- eveloping and maintaining an active space for collaboration among [MDIP Coalition](#mdip-coalition);
+- Developing and maintaining an active space for news, collaboration with and feedback from [MDIP Co-signatories](#mdip-co-signatories); and
+- Facilitating a decision-making process of the [MDIP Coalition](#mdip-coalition) to develop and regularly update the [MDIP Project Roadmap](definitions.md#mdip_project_roadmap).
+- Depending on the [MDIP Project Roadmap](definitions.md#mdip_project_roadmap), and available resources, the MDIP Manager MAY:
+- Identify, commit and or manage resources towards an Open Standards Project;
+- Regularly update the [MobilityDataverse](definitions.md#mobilitydataverse);
+- Develop and regularly update the [Open Standards Project Template](definitions.md#open-standards-project-template); and
+- Promote, expand, and regularly update the [Procurement Resource](definitions.md#mdip_procurement_resource).
+- The MDIP Manager MUST identify and work with the [MDIP Coalition Chair](#mdip-coalition-chair) to manage any organizational conflicts of interest.  The MDIP Manager MUST NOT engage in any activity in conflict with the Principles
+
+The MDIP Manager MUST
+
+- be a legal organization or individual capable of receiving and managing US Federal Funding; and
+- be in good standing with their legal domicile.
+
+### MDIP Program Manager
+
+Chosen by the [MDIP Manager](#mdip-manager), this individual MUST serve as the main contact between the [MDIP Coalition](#mdip-coalition) and the [MDIP Manager](#mdip-manager).
+
+## Document Changelog
+
+#### 2023-12-07 Initial Documentation
+
+Initial documentation of governance as approved by coalition over email.

--- a/docs/policies/code-of-conduct.md
+++ b/docs/policies/code-of-conduct.md
@@ -1,0 +1,61 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people  
+- Being respectful of differing opinions, viewpoints, and experiences  
+- Giving and gracefully accepting constructive feedback  
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience  
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+The [MDIP Manager](../governance.md/#mdip-manager), led by the [MDIP Program Manager](../governance.md/#mdip-program-manager) and under the guidance of the [MDIP Coalition](../governance.md/#mdip-coalition) are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.  
+
+The [MDIP Manager](../governance.md/#mdip-manager) has the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at EMAIL. All complaints will be reviewed and investigated promptly and fairly. All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+### Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+| **Level** | **Community Impact** | **Consequence** |
+| --------- | -------------------- | --------------- |
+| **Correction** | Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community. | A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested. |
+| **Warning** | A violation through a single incident or series of actions. | A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban. |
+| **Temporary Ban** | A serious violation of community standards, including sustained inappropriate behavior. | A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban. |
+| **Permanent Ban** | Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals. | A permanent ban from any sort of public interaction within the community. |
+
+## Attribution
+
+This Code of Conduct is adapted from the [TIDES Code of Conduct](https://github.com/TIDES-transit/TIDES/blob/main/CODE_OF_CONDUCT.md), which was in turn influenced by [Contributor Covenant version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html) and [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+## Document Changelog
+
+#### 2023-12-07 Initial Documentation
+
+Initial documentation of governance as approved by coalition over email.

--- a/docs/policies/digital-access.md
+++ b/docs/policies/digital-access.md
@@ -1,0 +1,28 @@
+# Digital Access
+
+## Contributor-Level
+
+Contributor-level Access shall be defined as the ability to read, edit and write.
+
+The following roles MUST be offered Contributor-level Access to the [MDIP Repository Organization](../definitions.md#mdip_repository_organization) and [MDIP Shared Folder](../definitions.md#mdip_shared_folder):
+
+- [MDIP Manager](../governance.md/#mdip-manager) staff
+- [MDIP Coalition Coordinator](../governance.md/#mdip-coalition-coordinator)
+- [MDIP Coalition](../governance.md/#mdip-coalition)
+- Anyone else at the discretion of the [MDIP Coalition Chair](../governance.md/#mdip-coalition-chair)
+
+## Ownership-level
+
+Ownership-level access shall be defined as Contributor-level Access with the addition of the ability to add or revoke user privileges.
+
+The following roles MUST be offered ownership-level access to the MDIP Repository Organization and MDIP Shared Folder:
+
+- [MDIP Coalition Chair](../governance.md/#mdip-coalition-chair)
+- [MDIP Program Manager](../governance.md/#mdip-program-manager)
+- Anyone else at the discretion of the [MDIP Coalition Chair](../governance.md/#mdip-coalition-chair)
+
+## Document Changelog
+
+#### 2023-12-07 Initial Documentation
+
+Initial documentation of governance as approved by coalition over email.

--- a/docs/policies/management.md
+++ b/docs/policies/management.md
@@ -1,0 +1,21 @@
+# Management
+
+## Appointment
+
+The [MDIP Coalition](../governance.md/#mdip-coalition) SHOULD appoint an individual or organization to serve as the [MDIP Manager](../governance.md/#mdip-manager). In order to appoint an [MDIP Manager](../governance.md/#mdip-manager), the [MDIP Coalition](../governance.md/#mdip-coalition) MUST execute a memorandum of understanding with that organization or individual which recognizes them in that role and articulates the expectations of both parties and the period of performance.
+
+## Severance
+
+If the [MDIP Manager](../governance.md/#mdip-manager) fails to serve adequately in the role, the [MDIP Coalition](../governance.md/#mdip-coalition) SHOULD seek a remedy through:
+
+- First discussing specific concerns with the [MDIP Manager](../governance.md/#mdip-manager)to resolve any miscommunication about role responsibilities;
+- If the concerns remain outstanding, mutually agree to a performance improvement plan with specific performance milestones over a period not to exceed three months; and
+- If the milestones are not met, explore termination of the organization or individual in fulfilling the [MDIP Manager](../governance.md/#mdip-manager) role.
+
+The [MDIP Coalition](../governance.md/#mdip-coalition) SHOULD provide as much financial or in-kind support as is practicable to the [MDIP Manager](../governance.md/#mdip-manager) in supporting the activities articulated in the MDIP Roadmap including identifying and helping secure grants, memberships, and direct financial support.
+
+## Document Changelog
+
+#### 2023-12-07 Initial Documentation
+
+Initial documentation of governance as approved by coalition over email.

--- a/docs/policies/mdip-coalition-composition.md
+++ b/docs/policies/mdip-coalition-composition.md
@@ -1,0 +1,43 @@
+# MDIP Coalition Composition
+
+## Eligibility
+
+[MDIP Coalition](../governance.md#mdip-coalition) members (“Members”) MUST be:
+
+- A public sector or nonprofit organization; and
+- Committed to realizing the vision of the Principles.
+
+The [MDIP Coalition](../governance.md#mdip-coalition) MAY be of any size.
+
+## Admission Process
+
+Additional Members MUST be admitted through a process which includes:
+
+- Appropriate decision-making within their respective organization that is required to become a Member;
+- Indication of a desire to become a Member to the [MDIP Program Manager](../governance.md/#mdip-program-manager) or an existing Member;
+- Written indiciation of their commitment to realizing the vision of the Principles to the [MDIP Program Manager](../governance.md/#mdip-program-manager);
+- Approval of their membership by the current [MDIP Coalition](../governance.md#mdip-coalition).
+
+## Participation Expectations
+
+Each Member SHOULD:
+
+- Provide a logo to the [MDIP Program Manager](../governance.md/#mdip-program-manager) for use on [MDIP Documentation](../definitions.md#mdip_documentation) and the [MDIP Website](../definitions.md#mdip_website);
+- Actively participate in the responsibilities of the [MDIP Coalition](../governance.md#mdip-coalition);
+- Name a [MDIP Coalition Organizational Representative](../governance.md#mdip-coalition-organizational-representative).
+
+## Severance
+
+Members MAY resign as a Member by indicating their desire to do so in written communication to the [MDIP Program Manager](../governance.md/#mdip-program-manager) or [MDIP Coalition Chair](../governance.md#mdip-coalition-chair). Ideally, this communication provides an indication of their reasoning for this action.
+
+Members MAY be removed from the [MDIP Coalition](../governance.md#mdip-coalition) for violating the Member requirement of commitment to the Principles or for violating the Code of Conduct. For a Member to be removed from the [MDIP Coalition](../governance.md#mdip-coalition):
+
+- A Member or the [MDIP Manager](../governance.md/#mdip-manager) MUST request their removal in writing to the [MDIP Coalition Chair](../governance.md#mdip-coalition-chair) which includes the reasoning;
+- The Member in question MUST be given an opportunity to remedy the situation (e.g. selecting a different [MDIP Coalition Organizational Representative](../governance.md#mdip-coalition-organizational-representative)); and
+- The [MDIP Coalition](../governance.md#mdip-coalition) MUST approve of the removal following the Member’s opportunity to remedy the cause.
+
+## Document Changelog
+
+#### 2023-12-07 Initial Documentation
+
+Initial documentation of governance as approved by coalition over email.

--- a/docs/policies/mdip-coalition-decision-making.md
+++ b/docs/policies/mdip-coalition-decision-making.md
@@ -1,0 +1,66 @@
+# MDIP Coalition Decision-Making
+
+In order to be considered approved by the [MDIP Coalition](../governance.md#mdip-coalition), relevant documents and policies MUST be voted on by at least ⅔ of the [MDIP Coalition](../governance.md#mdip-coalition members) and be approved by ⅔ of the members who choose to vote.
+
+## Process
+
+A vote MAY be initiated orally at a meeting of the Coalition by any Coalition member or the [MDIP Coalition Coordinator](../governance.md#mdip-coalition-coordinator) (“the Proposer”), but MUST be accompanied by a written call for the vote at which time the minimum voting period commences. The written call for a vote MUST contain a link to any supporting material in question as well as the voting time period, which MUST not be less than 72 hours.  
+
+The [MDIP Coalition Coordinator](../governance.md#mdip-coalition-coordinator) SHOULD disseminate a ‘last call’ for votes between 12 and 32 hours before the voting time period closes.  
+
+The [MDIP Coalition Coordinator](../governance.md#mdip-coalition-coordinator) SHOULD extend the voting time period by up to a week if the requisite number of Coalition members (⅔) have not cast their vote.
+
+MDIP Coalition Organizational Representatives  SHOULD vote on a proposal either orally at a meeting, or in writing to the [MDIP Coalition Coordinator](../governance.md#mdip-coalition-coordinator) and the rest of the Coalition. Votes, especially votes of dissent, SHOULD be accompanied with reasoning and relevant suggestions for “getting to yes”.  [MDIP Coalition Organizational Representatives](../governance.md#mdip-coalition-organizational-representative) may amend their vote at any time during the voting period.
+
+Any member of the Coalition, or MAY request a pause in the voting for an opportunity to discuss the proposal at a meeting of the Coalition. If requested, the [MDIP Coalition Coordinator](../governance.md#mdip-coalition-coordinator) MUST organize a meeting within one-week of the request.
+
+The Proposer MAY withdraw or amend their proposal at any time during the voting period, but votes made prior to any amendment MUST be recast.
+
+## Items Requiring Co-author Approval
+
+The following items MUST be subject to the approval of the [MDIP Coalition](../governance.md#mdip-coalition) upon any [Normative Change](../definitions.md#normative_change):
+
+- MDIP Coalition Composition
+- [MDIP Manager](../governance.md#mdip-manager) selection
+- The Principles
+- [MDIP Definitions](../definitions.md#mdip_definitions)
+- [MDIP Implementation Responsibilities](../definitions.md#mdip_implementation_responsibilities)
+- [MDIP Roadmap](../definitions.md#mdip_project_roadmap)
+- [MDIP Resources](../definitions.md#mdip_resources)
+- [MDIP Governance](../definitions.md#mdip_governance)
+- Memorandums of understanding (MOUs)
+- Other agreements which bind the MDIP Project to anything including grant agreements and contracts.
+
+*Non-normative changes SHALL NOT require any [MDIP Coalition](../governance.md#mdip-coalition) Approval.*
+
+## Decision Documentation
+
+The [MDIP Coalition Coordinator](../governance.md#mdip-coalition-coordinator) MUST ensure that [MDIP Coalition](../governance.md#mdip-coalition) decisions are recorded in meeting minutes stored on the MDIP Shared Folder.
+
+The [MDIP Manager](../governance.md#mdip-manager) MUST ensure that [MDIP Coalition](../governance.md#mdip-coalition) decisions:
+
+- Result in relevant updates to the [MDIP Website](../definitions.md#mdip_website) within one week of approval.
+- Are reflected in relevant document change-logs.
+
+## Example Process
+
+The following bullets summarize the implementation of the above process for a relatively agreeable change:
+
+1. Updated [MDIP Roadmap](../definitions.md#mdip_project_roadmap) presented to [MDIP Coalition](../governance.md#mdip-coalition) which needs their approval.
+2. Proposed document is amended in real-time during the meeting to address concerts of the [MDIP Coalition](../governance.md#mdip-coalition).
+3. [MDIP Coalition Coordinator](../governance.md#mdip-coalition-coordinator) calls a vote at the meeting and 10 out of 20 Coalition members who are there cast their vote orally and approve.
+4. [MDIP Coalition Coordinator](../governance.md#mdip-coalition-coordinator) disseminates a call for a vote with a link to the proposed document and a time period for voting in 5 days (in consideration that some days that week are a holiday for some).
+5. 1 [MDIP Coalition](../governance.md#mdip-coalition) member asks some questions in-line in the proposed document which other [MDIP Coalition](../governance.md#mdip-coalition) members respond to since they were discussed at the meeting.
+6. 4 of the remaining 10 Coalition members cast their affirmative vote via email.
+[MDIP Coalition Coordinator](../governance.md#mdip-coalition-coordinator) emails a “last call” for votes.
+7. 2 of the remaining 6 [MDIP Coalition](../governance.md#mdip-coalition) members cast their affirmative vote via email.
+8. [MDIP Coalition Coordinator](../governance.md#mdip-coalition-coordinator) emails a tally of the resulting vote:
+    - [x] 16/20 members voted
+    - [x] 16/16 voted to approve
+9. [MDIP Coalition Coordinator](../governance.md#mdip-coalition-coordinator) and [MDIP Manager](../governance.md#mdip-manager) appropriately document the vote and update relevant documents.
+
+## Document Changelog
+
+#### 2023-12-07 Initial Documentation
+
+Initial documentation of governance as approved by coalition over email.

--- a/docs/policies/openness-transparency.md
+++ b/docs/policies/openness-transparency.md
@@ -1,0 +1,32 @@
+# Openness + Transparency
+
+The following items MUST available free from cost to viewers at the [MDIP Website](../definitions.md#mdip_website):
+
+- Principles,
+- [MDIP Definitions](../definitions.md),
+- [MDIP Implementation Responsibilities](../definitions.md#mdip_implementation_responsibilities),
+- [MDIP Resources](../definitions.md#mdip_resources),
+- [MDIP Governance](../definitions.md#mdip_governance),
+- [MDIP Coalition](../governance.md/#mdip-coalition) membership,
+- [MDIP Coalition Chair](../governance.md/#mdip-coalition-chair),
+- [MDIP Co-signatories](../governance.md/#mdip-co-signatories) membership,
+- [MDIP Manager](../governance.md/#mdip-manager),
+- [MDIP Program Manager](../governance.md/#mdip-program-manager) and their contact information, and
+- [MDIP Coalition Coordinator](../governance.md/#mdip-coalition-coordinator).
+
+The following items MUST be licensed by the MDIP Coalition under a CC-BY (e.g. [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)) license:
+
+- Principles,
+- [MDIP Definitions](../definitions.md),
+- [MDIP Implementation Responsibilities](../definitions.md#mdip_implementation_responsibilities),
+- [MDIP Website](../definitions.md#mdip_website),
+- [MDIP Documentation](../definitions.md#mdip_documentation), and
+- [MDIP Resources](../definitions.md#mdip_resources).
+
+Any code supporting the MDIP Project MUST be licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+## Document Changelog
+
+#### 2023-12-07 Initial Documentation
+
+Initial documentation of governance as approved by coalition over email.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,17 @@ nav:
     - Support: support.md
     - Procurement: procurement.md
     - Resources: resources.md
-    - Details: definitions.md
+    - Governance:
+      - Structure: governance.md
+      - Policies:
+          Code of Conduct: policies/code-of-conduct.md
+          Digital Access: policies/digital-access.md
+          Coalition Composition: policies/mdip-coalition-composition.md
+          Coalition Decision-Making: policies/mdip-coalition-decision-making.md
+          Management: policies/management.md
+          Openness + Transparency: policies/openness-transparency.md
+    - Glossary: definitions.md
+
 
 theme:
   name: material
@@ -74,7 +84,6 @@ markdown_extensions:
       permalink: " ¶"
       toc_depth: 2
   - smarty
-  - fontawesome_markdown
   - pymdownx.details
   - pymdownx.snippets
   - abbr


### PR DESCRIPTION
Fixes rest of #21 which implements governance model that was approved by the MDIP Coalition and also adds the relevant definitions.

Additionally, fixes #24 which just makes sure that both LICENSES are in the repo.