### PR TITLE
Update coalition.md to include SoundTransit

### DIFF
--- a/docs/coalition.md
+++ b/docs/coalition.md
@@ -15,6 +15,7 @@
 - [Open Mobility Foundation (OMF)](https://www.openmobilityfoundation.org/)
 - [Oregon Department of Transportation (ODOT)](https://www.oregon.gov/odot/pages/index.aspx)
 - [Shared Use Mobility Center (SUMC)](https://sharedusemobilitycenter.org/)
+- [Sound Transit](https://www.soundtransit.org/)
 - [the Taskar Center for Accessible Technology](https://tcat.cs.washington.edu/)
 - [TriMet](https://trimet.org/home/)
 - [Vermont Agency of Transportation](https://vtrans.vermont.gov/)


### PR DESCRIPTION
As of Friday, 3/28/25, Sound Transit has been added to the MDIP coalition. This update adds them to the list and links to their website.